### PR TITLE
cpaital letters in name was a problem with my node install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "iSamples Web UI",
+  "name": "isampleswebui",
   "version": "0.1.0",
   "private": true,
   "homepage": ".",


### PR DESCRIPTION
i had an issue with the capital letters and spaces for the project name in the package.json file.  This was running under npm v6 (which i have to use on Mac M1 chip for installing packages).