### PR TITLE
Bug in React about where it wants to insert its script elements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script src="%PUBLIC_URL%/config.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
@@ -8,7 +9,6 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <script src="%PUBLIC_URL%/config.js" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" />
     <title>React App</title>


### PR DESCRIPTION
On building the Docker image locally, I noticed that React was inserting `script` elements incorrectly, which caused Cesium to break.  As a workaround, I was able to move the external script reference earlier in the html.