### PR TITLE
Async pointstream

### DIFF
--- a/src/components/cesium_map/api/server.js
+++ b/src/components/cesium_map/api/server.js
@@ -105,12 +105,12 @@ export class ISamplesAPI {
  *
  * @todo abort the fetch process
  */
-function pointStream(query, perdoc_cb = null, finaldoc_cb = null, error_cb = null) {
+async function pointStream(query, perdoc_cb = null, finaldoc_cb = null, error_cb = null) {
   // There is no documantation about it.
   // See the source code:
   //    https://github.com/jimhigson/oboe.js/blob/52d150dd78b20205bd26d63c807ac170c03f0f64/dist/oboe-browser.js#L2040
   // reture oboe instance so we could abort fetch
-  return oboe(window.config.solr_stream + "?" + setSolrQuery(query))
+  return await oboe(window.config.solr_stream + "?" + setSolrQuery(query))
     .node('docs.*', (doc) => {
       if (perdoc_cb !== null) {
         perdoc_cb(doc);

--- a/src/components/cesium_map/api/spatial.js
+++ b/src/components/cesium_map/api/spatial.js
@@ -289,7 +289,7 @@ export class PointStreamPrimitiveCollection extends Cesium.PointPrimitiveCollect
   }
 
   // function to query results and add point into cesium
-  load(facet, params) {
+  async load(facet, params) {
     let locations = {};
     // display loading page
     this.loading = document.getElementById("loading");
@@ -299,7 +299,7 @@ export class PointStreamPrimitiveCollection extends Cesium.PointPrimitiveCollect
     const field = facet ? Object.keys(facet)[0] : 'source';
     const CV = facet ? facet[field] : source;
 
-    return pointStream(
+    return await pointStream(
       params,
       (doc) => {
         // Handle the data records, e.g. response.docs[0].doc

--- a/src/components/cesium_map/cesium_UI.js
+++ b/src/components/cesium_map/cesium_UI.js
@@ -232,11 +232,14 @@ class CesiumMap extends React.Component {
     };
     // set time interval to check the current view every 5 seconds and update points
     this.checkPosition = setInterval(() => {
+      const loading = document.getElementById("loading").style.display;
       let diffDistance = distanceInKm(cameraLat, cameraLong, viewer.currentView.latitude, viewer.currentView.longitude);
       // update the points every 5 seconds if two points differ in 50km + scale of height.
       // I scale the current height by 15000000, the height of "View Global".
       // 4000 km is the distance that rotate half earth map on the height 15000000.
-      if (diffDistance > MINIMUM_REFRESH_DISTANCE + MAXIMUM_REFRESH_DISTANCE * viewer.currentView.height / MAXIMUM_ZOOM_DISTANCE) {
+      // Update:
+      //      A new parameter loading to indicate if the users cick somewhere and avoid intervel to check positions.
+      if (loading && diffDistance > MINIMUM_REFRESH_DISTANCE + MAXIMUM_REFRESH_DISTANCE * viewer.currentView.height / MAXIMUM_ZOOM_DISTANCE) {
         clearBoundingBox(true);
         this.updatePrimitive(viewer.currentView.latitude, viewer.currentView.longitude);
         // update camera position to the url

--- a/src/components/cesium_map/cesium_UI.js
+++ b/src/components/cesium_map/cesium_UI.js
@@ -176,12 +176,16 @@ class CesiumMap extends React.Component {
               className="margin-right-xs Cesium-input"
               placeholder="Please enter"
               type="number"
+              min={-180}
+              max={180}
               step="any" ></input>
             <label className="margin-right-xs Cesium-label">Latitude: </label>
             <input id="latitudeInput"
               className="margin-right-xs Cesium-input"
               placeholder="Please enter"
               type="number"
+              min={-90}
+              max={90}
               step="any" ></input>
             <button className="btn btn-default btn-sm cesium-button"
               onClick={this.submitLL.bind(this)}>
@@ -297,7 +301,8 @@ class CesiumMap extends React.Component {
       oboePrimitive.abort();
     }
 
-    oboePrimitive = setPrimitive.load(facet, { Q: "producedBy_samplingSite_location_cesium_height%3A*", field: "source", lat: latitude, long: longitude, searchFields: searchFields, rows: NUMBER_OF_POINTS });
+    setPrimitive.load(facet, { Q: "producedBy_samplingSite_location_cesium_height%3A*", field: "source", lat: latitude, long: longitude, searchFields: searchFields, rows: NUMBER_OF_POINTS })
+      .then(res => oboePrimitive = res);
     cameraLat = latitude;
     cameraLong = longitude;
   }


### PR DESCRIPTION
https://github.com/isamplesorg/isamples_webui/issues/91 The issue is caused by `setIntervel`. We used `setIntervel` to check the camera position and current position every 5 seconds. If the time that `setIntervel` checks the position is almost the same as the time that the users click a new position, this behavior would cause twice position updates and twice data loads. Then, the UI would be frozen for several seconds.