### PR TITLE
Preserve the selected columns in table 

### DIFF
--- a/src/components/react_table.js
+++ b/src/components/react_table.js
@@ -2,12 +2,11 @@ import React, { useState } from "react";
 import { useTable } from "react-table";
 import { ResultWrapper } from "./utilities";
 import cx from "classnames";
-
+import { store } from "redux/store";
 function Table(props) {
 
-  const { docs, fields } = props;
+  const { docs, fields, handleHiddenCols  } = props;
   const [collapse, setCollapse] = useState(false);
-
   // https://react-table.tanstack.com/docs/quick-start
   // Setup data and columns for react table
   // We must use "data", "columns" variable names for the useTable
@@ -54,12 +53,19 @@ function Table(props) {
     prepareRow,
     allColumns,
     getToggleHideAllColumnsProps,
-  } = useTable({ columns, data });
+  } = useTable({ columns, data, initialState : { hiddenColumns:  store.getState()['query']['view']['hiddenColumns'] } });
 
   const toggleExpand = () => {
     setCollapse(!collapse)
   };
 
+  // handler function that is invoked when user clicks the checkbox
+  // this will receive the selected field and pass it to the parent component
+  // in the parent component, this selected field will be stored in redux store
+  const handleClick = (e, column) =>{
+    handleHiddenCols(column);
+  }
+  
   return (
     <>
       <div className="field_select_group">
@@ -78,7 +84,7 @@ function Table(props) {
             {allColumns.map(column => (
               <div key={column.id}>
                 <label>
-                  <input type="checkbox" {...column.getToggleHiddenProps()} />{' '}
+                  <input type="checkbox" {...column.getToggleHiddenProps()}  onClick={(e) => handleClick(e, column)} />{' '}
                   {column.Header}
                 </label>
               </div>

--- a/src/components/react_table.js
+++ b/src/components/react_table.js
@@ -53,7 +53,8 @@ function Table(props) {
     prepareRow,
     allColumns,
     getToggleHideAllColumnsProps,
-  } = useTable({ columns, data, initialState : { hiddenColumns:  store.getState()['query']['view']['hiddenColumns'] } });
+  } = useTable({ columns, data, initialState : { hiddenColumns:  store.getState()['query']['view']['hiddenColumns'] ?  store.getState()['query']['view']['hiddenColumns'] : []
+  } });
 
   const toggleExpand = () => {
     setCollapse(!collapse)

--- a/src/extension/iSamples_resultList.js
+++ b/src/extension/iSamples_resultList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useState } from "react";
+import React from "react";
 import cx from "classnames";
 import Table from 'components/react_table';
 import CesiumMap from "components/cesium_map/cesium_UI";
@@ -22,7 +22,7 @@ class ResultList extends React.Component {
     // update hidden columns array 
     const updatedHiddenCols = this.state.hiddenCols;
     // add only if it did not exist in the previous state
-    if(updatedHiddenCols.indexOf(col['id']) == -1){
+    if(updatedHiddenCols.indexOf(col['id']) === -1){
       updatedHiddenCols.push(col['id']);
     }
     // set the view, and this will invoke the solr client to save the updated state in redux store 

--- a/src/extension/iSamples_resultList.js
+++ b/src/extension/iSamples_resultList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from "react";
+import React, { useState } from "react";
 import cx from "classnames";
 import Table from 'components/react_table';
 import CesiumMap from "components/cesium_map/cesium_UI";
@@ -9,7 +9,27 @@ import {connect} from "react-redux";
 import FadeLoader from "react-spinners/FadeLoader";
 
 class ResultList extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      hiddenCols: [], // initial state
+      facet:""
+    }
+  }
 
+  // handler function that is invoked from child component
+  handleHiddenCols = (col) => {
+    // update hidden columns array 
+    const updatedHiddenCols = this.state.hiddenCols;
+    // add only if it did not exist in the previous state
+    if(updatedHiddenCols.indexOf(col['id']) == -1){
+      updatedHiddenCols.push(col['id']);
+    }
+    // set the view, and this will invoke the solr client to save the updated state in redux store 
+    this.props.setView({ ...store.getState()['query']['view'], facet:this.state.facet, "hiddenColumns": this.state.hiddenCols});
+    // rerender the component
+    this.setState({hiddenCols : updatedHiddenCols}) 
+  }
 
   // prevent unnecessary rerendering
   shouldComponentUpdate(nextProps) {
@@ -34,7 +54,8 @@ class ResultList extends React.Component {
   // This function and shouldComponentUpdate are very similar.
   // Only view buttons need to set view to url.
   switchFormat = (format) => {
-    this.props.setView({ ...store.getState()['query']['view'], facet: format });
+    this.setState({hiddenCols:this.state.hiddenCols, facet:format})
+    this.props.setView({ ...store.getState()['query']['view'], facet: format, "hiddenColumns": store.getState()['query']['view']['hiddenCols']});
   }
 
   spinner = () => {
@@ -103,6 +124,7 @@ class ResultList extends React.Component {
                 <Table
                   docs={doc}
                   fields={fields}
+                  handleHiddenCols = {this.handleHiddenCols.bind(this)}
                 />
               </div>
               <div style={showView('Map')}>


### PR DESCRIPTION
Preserve the selected columns in table by storing it into redux store. We do this by having the redux store to store the hidden columns (columns that we want to not show) by invoking the solrClient. As result, this change in the store state will re-write the cookies. 