### PR TITLE
recover handling for non-hierarchy facets

### DIFF
--- a/src/extension/iSamples_hierarchyFacet.js
+++ b/src/extension/iSamples_hierarchyFacet.js
@@ -1,0 +1,147 @@
+import PropTypes from 'prop-types';
+import React from "react";
+import cx from "classnames";
+import CustomizedTreeView from 'components/CV_hierarchy/hierarchy';
+import material from 'CVJSON/material_hierarchy.json';
+import sampledFeature from "CVJSON/sampledFeature_hierarchy.json";
+import specimanType from "CVJSON/specimenType_hierarchy.json";
+
+class HierarchyFacet extends React.Component{
+
+    constructor(props) {
+        super(props);
+        this.state = {
+          filter: "",
+          truncateFacetListsAt: props.truncateFacetListsAt
+        };
+    }
+
+    // helper function
+    // adds all the children label of this key 
+    expandLabelSelectedHelper = (currSchema, childLabels) => {
+        for (const key in currSchema){
+            if (currSchema[key]["children"].length > 0){
+                for (const childSchema of currSchema[key]["children"]){
+                // recursively call to add other child labels 
+                for (const childKey in childSchema){
+                    const childLabel = childSchema[childKey]["label"]["en"]
+                    if (!childLabels.includes(childLabel)){
+                    childLabels.push(childLabel)
+                    }
+                }
+                this.expandLabelSelectedHelper(childSchema, childLabels)
+                }
+            }
+        }
+        
+    }
+
+    expandLabelSelected = (selected, currSchema, childLabels) => {
+        for (const key in currSchema){
+        const label = currSchema[key]["label"]["en"];
+        if (label === selected){
+            // get all the children nodes from here
+            this.expandLabelSelectedHelper(currSchema,childLabels);
+        }
+        for (const childSchema of currSchema[key]["children"]){
+            // recursively call to find the selected label 
+            this.expandLabelSelected(selected, childSchema, childLabels)
+        }
+        }
+    }
+
+    /**
+     * Static json for now.
+     * Will use REST api to get json file from server
+     */
+    hierarchy = (label) => {
+        switch (label) {
+        case "Material":
+            return material;
+        case "Context":
+            return sampledFeature;
+        case "Specimen":
+            return specimanType;
+        default:
+            return null;
+        }
+    }
+
+    handleClick = (value, mode) => {
+        // whenever a new label is clicked select all of the children labels 
+        const currSchema = this.hierarchy(this.props.label);
+        const expandedLabels = [value]
+        this.expandLabelSelected(value, currSchema, expandedLabels); // expand recursively
+        // filter out labels that are already existing
+        expandedLabels.filter((item) => {
+            return this.props.value.indexOf(item) === -1
+        })
+        if (mode === "delete"){
+            // value is the node to be deleted
+            const foundIdx = this.props.value.indexOf(value);
+            // delete the node and the expanded children nodes 
+            this.props.value =  this.props.value.filter((v, i) => i !== foundIdx && expandedLabels.indexOf(v) === -1);
+            this.props.onChange(this.props.field, this.props.value);
+        }
+        else if (mode === "add") {
+            // add the node and the expanded children nodes
+            this.props.onChange(this.props.field, this.props.value.concat(expandedLabels));
+        }
+    }
+
+    toggleExpand() {
+        this.props.onSetCollapse(this.props.field, !(this.props.collapse || false));
+    }
+
+    render(){
+        const { label, facets, field, value, bootstrapCss, collapse } = this.props;
+        const facetCounts = facets? facets.filter((facet, i) => i % 2 === 1):[];
+        const facetValues =  facets? facets.filter((facet, i) => i % 2 === 0):[]
+    
+        const expanded = !(collapse || false);
+
+        return (
+        <li className={cx("hierarchy-facet", { "list-group-item": bootstrapCss })} id={`solr-list-facet-${field}`}>
+            <header onClick={this.toggleExpand.bind(this)}>
+            <h5>
+                {bootstrapCss ? (<span>
+                <span className={cx("glyphicon", {
+                    "glyphicon-collapse-down": expanded,
+                    "glyphicon-collapse-up": !expanded
+                })} />{" "}
+                </span>) : null}
+                {label}
+            </h5>
+            </header>
+
+            {expanded ?
+                <CustomizedTreeView label={label} value={value} facetCounts={facetCounts} facetValues={facetValues} onClick={this.handleClick} hierarchy= {this.hierarchy}/>
+            : null}
+        </li>
+        );
+    }
+    
+}
+
+HierarchyFacet.defaultProps = {
+    value: []
+};
+  
+HierarchyFacet.propTypes = {
+    bootstrapCss: PropTypes.bool,
+    children: PropTypes.array,
+    collapse: PropTypes.bool,
+    facetSort: PropTypes.string,
+    facets: PropTypes.array.isRequired,
+    field: PropTypes.string.isRequired,
+    label: PropTypes.string,
+    onChange: PropTypes.func,
+    onFacetSortChange: PropTypes.func,
+    onSetCollapse: PropTypes.func,
+    query: PropTypes.object,
+    truncateFacetListsAt: PropTypes.number,
+    value: PropTypes.array
+};
+
+export default HierarchyFacet;
+

--- a/src/extension/iSamples_hierarchyFacet.js
+++ b/src/extension/iSamples_hierarchyFacet.js
@@ -101,7 +101,7 @@ class HierarchyFacet extends React.Component{
         const expanded = !(collapse || false);
 
         return (
-        <li className={cx("hierarchy-facet", { "list-group-item": bootstrapCss })} id={`solr-list-facet-${field}`}>
+        <li className={cx("hierarchy-facet", { "hierarchy-group-item": bootstrapCss })} id={`solr-hierarchy-facet-${field}`}>
             <header onClick={this.toggleExpand.bind(this)}>
             <h5>
                 {bootstrapCss ? (<span>

--- a/src/extension/iSamples_hierarchyFacet.js
+++ b/src/extension/iSamples_hierarchyFacet.js
@@ -101,7 +101,7 @@ class HierarchyFacet extends React.Component{
         const expanded = !(collapse || false);
 
         return (
-        <li className={cx("hierarchy-facet", { "hierarchy-group-item": bootstrapCss })} id={`solr-hierarchy-facet-${field}`}>
+        <li className={cx("hierarchy-facet", { "list-group-item": bootstrapCss })} id={`solr-hierarchy-facet-${field}`}>
             <header onClick={this.toggleExpand.bind(this)}>
             <h5>
                 {bootstrapCss ? (<span>

--- a/src/extension/iSamples_listFacet.js
+++ b/src/extension/iSamples_listFacet.js
@@ -78,24 +78,37 @@ class ListFacet extends React.Component {
   }
 
   handleClick = (value, mode) => {
-    // whenever a new label is clicked select all of the children labels 
-    const currSchema = this.hierarchy(this.props.label);
-    const expandedLabels = [value]
-    this.expandLabelSelected(value, currSchema, expandedLabels); // expand recursively
-    // filter out labels that are already existing
-    expandedLabels.filter((item) => {
-      return this.props.value.indexOf(item) === -1
-    })
-    if (mode === "delete"){
-      // value is the node to be deleted
+    const hierarchyFacet = ["Material", "Specimen"];
+    // check if the click is invoked on a hierarchy-related facet
+    if (!hierarchyFacet.includes(this.props.label)){
+      // if not, add or remove from list 
       const foundIdx = this.props.value.indexOf(value);
-      // delete the node and the expanded children nodes 
-      this.props.value =  this.props.value.filter((v, i) => i !== foundIdx && expandedLabels.indexOf(v) === -1);
-      this.props.onChange(this.props.field, this.props.value);
+      if (foundIdx < 0) {
+        this.props.onChange(this.props.field, this.props.value.concat(value));
+      } else {
+        this.props.onChange(this.props.field, this.props.value.filter((v, i) => i !== foundIdx));
+      }
     }
-    else if (mode === "add") {
-      // add the node and the expanded children nodes
-      this.props.onChange(this.props.field, this.props.value.concat(expandedLabels));
+    else{
+      // whenever a new label is clicked select all of the children labels 
+      const currSchema = this.hierarchy(this.props.label);
+      const expandedLabels = [value]
+      this.expandLabelSelected(value, currSchema, expandedLabels); // expand recursively
+      // filter out labels that are already existing
+      expandedLabels.filter((item) => {
+        return this.props.value.indexOf(item) === -1
+      })
+      if (mode === "delete"){
+        // value is the node to be deleted
+        const foundIdx = this.props.value.indexOf(value);
+        // delete the node and the expanded children nodes 
+        this.props.value =  this.props.value.filter((v, i) => i !== foundIdx && expandedLabels.indexOf(v) === -1);
+        this.props.onChange(this.props.field, this.props.value);
+      }
+      else if (mode === "add") {
+        // add the node and the expanded children nodes
+        this.props.onChange(this.props.field, this.props.value.concat(expandedLabels));
+      }
     }
   }
 

--- a/src/extension/iSamples_listFacet.js
+++ b/src/extension/iSamples_listFacet.js
@@ -1,11 +1,6 @@
 import PropTypes from 'prop-types';
 import React from "react";
 import cx from "classnames";
-import CustomizedTreeView from 'components/CV_hierarchy/hierarchy';
-import material from 'CVJSON/material_hierarchy.json';
-import sampledFeature from "CVJSON/sampledFeature_hierarchy.json";
-import specimanType from "CVJSON/specimenType_hierarchy.json";
-
 
 const CheckedIcon = () => {
   return <span className='glyphicon glyphicon-check' />
@@ -25,90 +20,12 @@ class ListFacet extends React.Component {
     };
   }
 
-
-  // helper function
-  // adds all the children label of this key 
- expandLabelSelectedHelper = (currSchema, childLabels) => {
-    for (const key in currSchema){
-      if (currSchema[key]["children"].length > 0){
-        for (const childSchema of currSchema[key]["children"]){
-          // recursively call to add other child labels 
-          for (const childKey in childSchema){
-            const childLabel = childSchema[childKey]["label"]["en"]
-            if (!childLabels.includes(childLabel)){
-              childLabels.push(childLabel)
-            }
-          }
-          this.expandLabelSelectedHelper(childSchema, childLabels)
-        }
-      }
-    }
-    
-  }
-
-  expandLabelSelected = (selected, currSchema, childLabels) => {
-    for (const key in currSchema){
-      const label = currSchema[key]["label"]["en"];
-      if (label === selected){
-        // get all the children nodes from here
-        this.expandLabelSelectedHelper(currSchema,childLabels);
-      }
-      for (const childSchema of currSchema[key]["children"]){
-        // recursively call to find the selected label 
-        this.expandLabelSelected(selected, childSchema, childLabels)
-      }
-    }
-  }
-
-  /**
- * Static json for now.
- * Will use REST api to get json file from server
- */
-  hierarchy = (label) => {
-    switch (label) {
-      case "Material":
-        return material;
-      case "Context":
-        return sampledFeature;
-      case "Specimen":
-        return specimanType;
-      default:
-        return null;
-    }
-  }
-
-  handleClick = (value, mode) => {
-    const hierarchyFacet = ["Material", "Specimen"];
-    // check if the click is invoked on a hierarchy-related facet
-    if (!hierarchyFacet.includes(this.props.label)){
-      // if not, add or remove from list 
-      const foundIdx = this.props.value.indexOf(value);
-      if (foundIdx < 0) {
-        this.props.onChange(this.props.field, this.props.value.concat(value));
-      } else {
-        this.props.onChange(this.props.field, this.props.value.filter((v, i) => i !== foundIdx));
-      }
-    }
-    else{
-      // whenever a new label is clicked select all of the children labels 
-      const currSchema = this.hierarchy(this.props.label);
-      const expandedLabels = [value]
-      this.expandLabelSelected(value, currSchema, expandedLabels); // expand recursively
-      // filter out labels that are already existing
-      expandedLabels.filter((item) => {
-        return this.props.value.indexOf(item) === -1
-      })
-      if (mode === "delete"){
-        // value is the node to be deleted
-        const foundIdx = this.props.value.indexOf(value);
-        // delete the node and the expanded children nodes 
-        this.props.value =  this.props.value.filter((v, i) => i !== foundIdx && expandedLabels.indexOf(v) === -1);
-        this.props.onChange(this.props.field, this.props.value);
-      }
-      else if (mode === "add") {
-        // add the node and the expanded children nodes
-        this.props.onChange(this.props.field, this.props.value.concat(expandedLabels));
-      }
+  handleClick = (value) => {
+    const foundIdx = this.props.value.indexOf(value);
+    if (foundIdx < 0) {
+      this.props.onChange(this.props.field, this.props.value.concat(value));
+    } else {
+      this.props.onChange(this.props.field, this.props.value.filter((v, i) => i !== foundIdx));
     }
   }
 
@@ -127,15 +44,13 @@ class ListFacet extends React.Component {
 
     const expanded = !(collapse || false);
 
-    const customList = ['Material', 'Specimen', 'Context'].includes(label);
-
     const showMoreLink = truncateFacetListsAt > -1 && truncateFacetListsAt < facetValues.length ?
       <li className={cx({ "list-group-item": bootstrapCss })} onClick={() => this.setState({ truncateFacetListsAt: -1 })}>
         Show all ({facetValues.length})
       </li> : null;
 
     const prevNode = <div>
-      <ul className={cx({ "list-group": bootstrapCss, "list-facet__custom--height": !customList })}>
+      <ul className={cx({ "list-group": bootstrapCss, "list-facet__custom--height": true})}>
         {facetValues.filter((facetValue, i) => truncateFacetListsAt < 0 || i < truncateFacetListsAt).map((facetValue, i) =>
           this.state.filter.length === 0 || facetValue.toLowerCase().indexOf(this.state.filter.toLowerCase()) > -1 ? (
             <li className={cx(`facet-item-type-${field}`, { "list-group-item": bootstrapCss })}
@@ -193,12 +108,7 @@ class ListFacet extends React.Component {
             {label}
           </h5>
         </header>
-
-        {expanded ?
-          (customList ?
-            <CustomizedTreeView label={label} value={value} facetCounts={facetCounts} facetValues={facetValues} onClick={this.handleClick} hierarchy= {this.hierarchy}/>
-            : prevNode)
-          : null}
+        {expanded ? prevNode : null}
       </li>
     );
   }

--- a/src/fields.js
+++ b/src/fields.js
@@ -14,8 +14,8 @@ const fields = [
   { field: "curation_responsibility", type: "non-search", hidden: true },
   { field: "description_text", type: "non-search", hidden: true },
   { label: "Context", field: "hasContextCategory", type: "list-facet", facetSort: "count", collapse: true },
-  { label: "Material", field: "hasMaterialCategory", type: "list-facet", facetSort: "count", collapse: true },
-  { label: "Specimen", field: "hasSpecimenCategory", type: "list-facet", facetSort: "count", collapse: true },
+  { label: "Material", field: "hasMaterialCategory", type: "hierarchy-facet", collapse: true },
+  { label: "Specimen", field: "hasSpecimenCategory", type: "hierarchy-facet", collapse: true },
   { label: "Identifier", field: "id", type: "text" },
   { field: "informalClassification", type: "non-search", hidden: true },
   { field: "keywords", type: "text" },
@@ -47,8 +47,6 @@ const sortFields = [
   { label: "Identifier", field: "id" },
   { label: "Source", field: "source" },
   { label: "Context", field: "hasContextCategory" },
-  { label: "Material", field: "hasMaterialCategory" },
-  { label: "Specimen", field: "hasSpecimenCategory" },
   { label: "Registrant", field: "registrant" },
   { label: "Collection Time", field: "producedBy_resultTime" }
 ];

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ import {
 import NavFooter from "pages/navFooter";
 import DOIs from 'pages/DOIs';
 import UserInfo from 'pages/userInfo';
+import HierarchyFacet from 'extension/iSamples_hierarchyFacet';
 
 // initializa a cookie instance
 const cookies = new Cookies();
@@ -68,6 +69,7 @@ const iSamples_componentPack = {
     ...defaultComponentPack.searchFields,
     text: TextSearch,
     "list-facet": ListFacet,
+    "hierarchy-facet" : HierarchyFacet,
     container: SearchFieldContainer,
     "date-range-facet": iSamples_RangeFacet,
     "non-search": TextSearch,
@@ -112,7 +114,7 @@ function App() {
       const searchFields = encode(JSON.stringify(getAllValueField(query['searchFields'])));
       searchParamsDict['searchFields'] = searchFields;
     }
-
+    
     if (checkAllValue(query['sortFields'])) {
       const sortFields = encode(JSON.stringify(getAllValueField(query['sortFields'])));
       searchParamsDict['sortFields'] = sortFields;
@@ -127,7 +129,6 @@ function App() {
       const view = encode(JSON.stringify(query['view']));
       searchParamsDict['view'] = view;
     }
-
     setSearchParams(searchParamsDict);
 
     // cookie library:


### PR DESCRIPTION
PR for #111. While supporting hierarchy facet click, recover the code to support the non-hierarchy facets ( `Source`, `Registrant` ) click. 