### PR TITLE
add initial checkbox for point rendering

### DIFF
--- a/src/components/cesium_map/api/spatial.js
+++ b/src/components/cesium_map/api/spatial.js
@@ -300,6 +300,15 @@ export class ISamplesSpatial {
       destination: place.destination,
       orientation: place.orientation
     });
+    // update the camera position
+    const updatedSpatialView = new SpatialView(
+      place.viewDict.longitude,
+      place.viewDict.latitude,
+      place.viewDict.height,
+      place.viewDict.heading,
+      place.viewDict.pitch
+    )
+    this.viewer.camera.setView(updatedSpatialView.getView)
   }
 
   /**

--- a/src/components/cesium_map/api/spatial.js
+++ b/src/components/cesium_map/api/spatial.js
@@ -126,9 +126,10 @@ function asDRectangle(rectangle) {
 * Requires that "oboe" is globally available.
 */
 export class PointStreamPrimitiveCollection extends Cesium.PointPrimitiveCollection {
-  constructor(terrain) {
+  constructor(terrain, display) {
     super(terrain)
     this.terrain = terrain;
+    this.display = display; // flag that indicates whether we want to fetch points 
   }
 
   clear() {
@@ -139,8 +140,17 @@ export class PointStreamPrimitiveCollection extends Cesium.PointPrimitiveCollect
     return this.lastPos;
   }
 
+  enableDisplay(){
+    this.display = true; 
+  }
+
+  disableDisplay(){
+    this.display = false; 
+  }
+
   // function to query results and add point into cesium
   async load(facet, params) {
+    if (!this.display) return;
     let locations = {};
     // display loading page
     this.loading = document.getElementById("loading");

--- a/src/components/cesium_map/api/spatial.js
+++ b/src/components/cesium_map/api/spatial.js
@@ -290,6 +290,10 @@ export class ISamplesSpatial {
     return this.worldTerrain;
   }
 
+  get camera(){
+    return this.viewer.camera; 
+  }
+
   /**
    * Fly to the provided SpatialView
    *
@@ -622,6 +626,8 @@ export class ISamplesSpatial {
     c.width = cc.width;
     c.style.left = cc.style.left;
     c.style.top = cc.style.top;
+
+
   }
 
   getScreenPosition(longitude, latitude) {

--- a/src/components/cesium_map/cesium_UI.js
+++ b/src/components/cesium_map/cesium_UI.js
@@ -28,9 +28,10 @@ Cesium.Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOi
 // constant variables
 const REFRESH_TIME_MS = 5000;
 const VIEWPOINT_TIME_MS = 2000;
-const UPDATE_RATIO = 0.7;
+const UPDATE_RATIO = 0.5;
 const MAXIMUM_ZOOM_DISTANCE = 15000000;
 const MAXIMUM_NUMBER_OF_POINTS = 100000;
+
 const GLOBAL_HEADING = 90;
 const GLOBAL_PITCH = -90;
 const api = new ISamplesAPI();
@@ -231,11 +232,10 @@ class CesiumMap extends React.Component {
       oboePrimitive.abort();
     }
     // calculate number of points of entire bounding box 
-    let entire_bbox = viewer.currentBounds
+    let entire_bbox = viewer.currentBounds;
     currNumPoints = await countRecordsInBB(entire_bbox);
-
     if (currNumPoints > MAXIMUM_NUMBER_OF_POINTS){
-      // do not fetch 
+      // do not load points 
       return; 
     }
 
@@ -262,6 +262,8 @@ class CesiumMap extends React.Component {
     if (!location.equalTo(this.props.mapInfo)) {
       this.props.setCamera({ facet: "Map", ...location.viewDict });
     }
+    // force an update of primitives whenever visiting location 
+    this.updatePrimitive(location.latitude, location.longitude); 
   };
 
   /**
@@ -285,6 +287,8 @@ class CesiumMap extends React.Component {
         moorea.heading,
         moorea.pitch));
     }
+    // force an update of primitives whenever changing view 
+    this.updatePrimitive(cameraLat, cameraLong);
   }
 
   /**

--- a/src/components/cesium_map/cesium_UI.js
+++ b/src/components/cesium_map/cesium_UI.js
@@ -368,7 +368,7 @@ class CesiumMap extends React.Component {
 
         if (startHeight > endHeight && exceedMaxPoints) {
             this.updatePrimitive(viewer.currentView.latitude, viewer.currentView.longitude)
-        } else if (!exceedMaxPoints) {
+        } else if (startHeight < endHeight && !exceedMaxPoints) {
             this.updatePrimitive(viewer.currentView.latitude, viewer.currentView.longitude)
         }
     });

--- a/src/components/cesium_map/cesium_UI.js
+++ b/src/components/cesium_map/cesium_UI.js
@@ -217,7 +217,7 @@ class CesiumMap extends React.Component {
   /**
  * This method clear all objects in the map
  * and render new point primitive based on new position
- *
+ * Rendering will be done only if the number of points in the current view is smaller than the maximum limit
  * @param {*} latitude
  * @param {*} longitude
  */
@@ -323,6 +323,11 @@ class CesiumMap extends React.Component {
     };
   };
 
+  /**
+   * Check box handler function
+   * When disabled display (default value), no query will be sent to the server to fetch and render points
+   * @param {*} e 
+   */
   handleChange = (e) => {
     display = e.target.checked;
     if (!e.target.checked){
@@ -336,6 +341,12 @@ class CesiumMap extends React.Component {
     }
   }
 
+  /**
+   * Updating the points based on zoom in/zoom out event
+   * When zoom in, check if we need to render the points
+   * and when zoom out, checks if we need to stop rendering the points 
+   * @param {*} spatial 
+   */
   enableZoomTracking(spatial){
     const camera = spatial.camera;
 
@@ -356,10 +367,8 @@ class CesiumMap extends React.Component {
         const endHeight = Cesium.Cartographic.fromCartesian(endPos).height;
 
         if (startHeight > endHeight && exceedMaxPoints) {
-            // if zooming in, check if we can render new points
             this.updatePrimitive(viewer.currentView.latitude, viewer.currentView.longitude)
         } else if (!exceedMaxPoints) {
-          // if zooming out, check if we exceeded the maximum possible points to render 
             this.updatePrimitive(viewer.currentView.latitude, viewer.currentView.longitude)
         }
     });

--- a/src/components/cesium_map/cesium_UI.js
+++ b/src/components/cesium_map/cesium_UI.js
@@ -56,6 +56,9 @@ let setPrimitive = null;
 // we might abort the stream fetch
 let oboePrimitive = null;
 
+// initial display is false - do not render points
+let display = false; 
+
 /**
  * This method queries the record amount in the bbox
  *
@@ -192,6 +195,7 @@ class CesiumMap extends React.Component {
             </button>
           </div>
         </div>
+        <p className="cesium-checkbox"><input type="checkbox" id="display" onChange={this.handleChange}/> <label for="display">Display Points </label></p>
         <button className="cesium-visit-button cesium-button" onClick={this.toggle}>Viewer Change</button>
       </>;
   };
@@ -303,6 +307,22 @@ class CesiumMap extends React.Component {
     };
   };
 
+  /**
+   * Change whether the display flag is true/false 
+   */
+  handleChange = (e) => {
+    display = e.target.checked;
+    if (!e.target.checked){
+      setPrimitive.clear();  // clear all points
+      setPrimitive.disableDisplay(); // disable display
+    }
+    else{
+      setPrimitive.enableDisplay(); 
+      // fetch back all points 
+      this.updatePrimitive(viewer.currentView.latitude, viewer.currentView.longitude);
+    }
+  }
+
   // This is a initial function in react liftcycle.
   // Only call once when this component first render
   componentDidMount() {
@@ -315,13 +335,13 @@ class CesiumMap extends React.Component {
       mapInfo.heading,
       mapInfo.pitch);
     viewer = new ISamplesSpatial("cesiumContainer", initialPosition || moorea);
-
+  
     // remove the Ceisum information with custom button group
     render(this.dropdown, document.querySelector("div.cesium-viewer-bottom"));
     viewer.addHud("cesiumContainer");
     viewer.trackMouseCoordinates(showCoordinates);
     viewer.enableTracking(api, (bb) => selectedBoxCallbox(bb, true));
-    setPrimitive = new PointStreamPrimitiveCollection(viewer.terrain);
+    setPrimitive = new PointStreamPrimitiveCollection(viewer.terrain, display);
     viewer.addPointPrimitives(setPrimitive);
     searchFields = newSearchFields;
     onChange = onSetFields;
@@ -388,7 +408,6 @@ class CesiumMap extends React.Component {
     clearBoundingBox(true);
     // update the point layer
     this.updatePrimitive(viewer.currentView.latitude, viewer.currentView.longitude);
-
     // update bounding box based on bbox
     const bb1 = JSON.stringify(nextProps.newBbox);
     const bb2 = JSON.stringify(this.props.newBbox);

--- a/src/css/cesiumMap.css
+++ b/src/css/cesiumMap.css
@@ -1,3 +1,16 @@
+.cesium-checkbox {
+  border: solid 1px #444;
+  background-color: #303336;
+  color:#edfffe;
+  display: inline-block;
+  vertical-align: middle;
+  margin: 5px;
+  border-radius: 5px;
+  box-sizing: border-box;
+  padding: 3px 12px;
+  font-weight: lighter;
+}
+
 .Cesium-popBox {
   position: absolute;
   top: -230px;


### PR DESCRIPTION
Work for PR #123 , PR #122 . 

- Create a checkbox to indicate whether to render the points or not. When user checks to not display the points, the query to fetch the 100,000 points will not be sent to the server (#123)
- In display mode, when there are more than 100,000 points to be rendered, do not render the points anymore (#122)