### PR TITLE
Not select child facet

### DIFF
--- a/src/css/solrFaceted.css
+++ b/src/css/solrFaceted.css
@@ -13,6 +13,20 @@ a {
   min-height: calc(100vh - 170px);
 }
 
+.hierarchy-facet {
+  overflow-y: auto;
+}
+.hierarchy-facet h5,h6 {
+  display: inline;
+}
+
+.switch {
+  
+  float:right;
+  margin-left: auto; 
+  margin-right: 0;
+}
+
 .list-facet ul {
   overflow-y: auto;
 }

--- a/src/fields.js
+++ b/src/fields.js
@@ -16,7 +16,7 @@ const fields = [
   { field: "curation_location", type: "non-search", hidden: true },
   { field: "curation_responsibility", type: "non-search", hidden: true },
   { field: "description_text", type: "non-search", hidden: true },
-  { label: "Context", field: "hasContextCategory", type: "list-facet", facetSort: "count", collapse: true },
+  { label: "Context", field: "hasContextCategory", type: "hierarchy-facet", collapse: true },
   { label: "Material", field: "hasMaterialCategory", type: "hierarchy-facet", collapse: true },
   { label: "Specimen", field: "hasSpecimenCategory", type: "hierarchy-facet", collapse: true },
   { label: "Identifier", field: "id", type: "text" },


### PR DESCRIPTION
Add a functionality to the hierarchy facet. When turn on/off of the toggle, we can include all of the children of the selected label or not in the search result. 