### PR TITLE
Run the vocab generation in the correct branch

### DIFF
--- a/.github/workflows/publish_pages.js.yml
+++ b/.github/workflows/publish_pages.js.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Install the python dependencies in the env
       working-directory: ./vocabularies/tools
       run: |
+        git checkout main
         pip install -r requirements.txt
     - name: Run the vocab scripts
       working-directory: ./vocabularies/tools

--- a/.github/workflows/publish_pages.js.yml
+++ b/.github/workflows/publish_pages.js.yml
@@ -31,10 +31,9 @@ jobs:
     - name: Install the python dependencies in the env
       working-directory: ./vocabularies/tools
       run: |
-        git checkout main
         pip install -r requirements.txt
     - name: Run the vocab scripts
-      working-directory: ./vocabularies/tools
+      working-directory: ./vocabularies/
       run: |
         make cache
         python tools/vocab.py -s cache/vocabularies.db uijson mat:materialsvocabulary -e >& ../src/CVJSON/material_hierarchy.json


### PR DESCRIPTION
This somehow got missed with the restructuring of the vocab repo